### PR TITLE
docs: Add AI Agent Context section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ yarn start
 | `/hot-scenes`     | `GET`      | Retrieves information about the most popular scenes currently active. |
 | `/main/about`     | `GET`      | Provides details about the default MAIN realm managed by the Archipelago workers. |
 
-## 🤖 AI Agent Context
+## AI Agent Context
 
 **Service Purpose:** Provides realm configuration service for Decentraland clients. Implements ADR-110 realm descriptions, enabling clients to discover and connect to available Catalyst nodes, Lambdas services, and communication realms (like the MAIN Archipelago realm).
 

--- a/README.md
+++ b/README.md
@@ -22,3 +22,35 @@ yarn start
 | `/hot-scenes`     | `GET`      | Retrieves information about the most popular scenes currently active. |
 | `/main/about`     | `GET`      | Provides details about the default MAIN realm managed by the Archipelago workers. |
 
+## 🤖 AI Agent Context
+
+**Service Purpose:** Provides realm configuration service for Decentraland clients. Implements ADR-110 realm descriptions, enabling clients to discover and connect to available Catalyst nodes, Lambdas services, and communication realms (like the MAIN Archipelago realm).
+
+**Key Capabilities:**
+
+- Lists available realms in the Catalyst Network
+- Provides realm descriptions with service endpoints (Catalyst URLs, Lambdas URLs, comms configurations)
+- Exposes hot scenes data (popular/active scenes) for client discovery
+- Provides MAIN realm information for Archipelago workers connection
+- Enables dynamic realm selection and load balancing across Catalyst nodes
+
+**Communication Pattern:** Synchronous HTTP REST API
+
+**Technology Stack:**
+
+- Runtime: Node.js
+- Language: TypeScript
+- HTTP Framework: @well-known-components/http-server
+- Component Architecture: @well-known-components (logger, metrics, http-server)
+
+**External Dependencies:**
+
+- Catalyst Network: Queries available Catalyst nodes for realm information
+- Archipelago Workers: MAIN realm status and configuration
+- Stats Service: Hot scenes data (from archipelago-workers stats service)
+
+**Key Concepts:**
+
+- **Realm**: A communication/render configuration specifying which Catalyst, Lambdas, and comms services to use
+- **MAIN Realm**: Default realm managed by Archipelago workers for Genesis City
+- **Hot Scenes**: Popular/active scenes for user discovery

--- a/README.md
+++ b/README.md
@@ -24,33 +24,4 @@ yarn start
 
 ## AI Agent Context
 
-**Service Purpose:** Provides realm configuration service for Decentraland clients. Implements ADR-110 realm descriptions, enabling clients to discover and connect to available Catalyst nodes, Lambdas services, and communication realms (like the MAIN Archipelago realm).
-
-**Key Capabilities:**
-
-- Lists available realms in the Catalyst Network
-- Provides realm descriptions with service endpoints (Catalyst URLs, Lambdas URLs, comms configurations)
-- Exposes hot scenes data (popular/active scenes) for client discovery
-- Provides MAIN realm information for Archipelago workers connection
-- Enables dynamic realm selection and load balancing across Catalyst nodes
-
-**Communication Pattern:** Synchronous HTTP REST API
-
-**Technology Stack:**
-
-- Runtime: Node.js
-- Language: TypeScript
-- HTTP Framework: @well-known-components/http-server
-- Component Architecture: @well-known-components (logger, metrics, http-server)
-
-**External Dependencies:**
-
-- Catalyst Network: Queries available Catalyst nodes for realm information
-- Archipelago Workers: MAIN realm status and configuration
-- Stats Service: Hot scenes data (from archipelago-workers stats service)
-
-**Key Concepts:**
-
-- **Realm**: A communication/render configuration specifying which Catalyst, Lambdas, and comms services to use
-- **MAIN Realm**: Default realm managed by Archipelago workers for Genesis City
-- **Hot Scenes**: Popular/active scenes for user discovery
+For detailed AI Agent context, see [docs/ai-agent-context.md](docs/ai-agent-context.md).

--- a/docs/ai-agent-context.md
+++ b/docs/ai-agent-context.md
@@ -1,0 +1,32 @@
+# AI Agent Context
+
+**Service Purpose:** Provides realm configuration service for Decentraland clients. Implements ADR-110 realm descriptions, enabling clients to discover and connect to available Catalyst nodes, Lambdas services, and communication realms (like the MAIN Archipelago realm).
+
+**Key Capabilities:**
+
+- Lists available realms in the Catalyst Network
+- Provides realm descriptions with service endpoints (Catalyst URLs, Lambdas URLs, comms configurations)
+- Exposes hot scenes data (popular/active scenes) for client discovery
+- Provides MAIN realm information for Archipelago workers connection
+- Enables dynamic realm selection and load balancing across Catalyst nodes
+
+**Communication Pattern:** Synchronous HTTP REST API
+
+**Technology Stack:**
+
+- Runtime: Node.js
+- Language: TypeScript
+- HTTP Framework: @well-known-components/http-server
+- Component Architecture: @well-known-components (logger, metrics, http-server)
+
+**External Dependencies:**
+
+- Catalyst Network: Queries available Catalyst nodes for realm information
+- Archipelago Workers: MAIN realm status and configuration
+- Stats Service: Hot scenes data (from archipelago-workers stats service)
+
+**Key Concepts:**
+
+- **Realm**: A communication/render configuration specifying which Catalyst, Lambdas, and comms services to use
+- **MAIN Realm**: Default realm managed by Archipelago workers for Genesis City
+- **Hot Scenes**: Popular/active scenes for user discovery


### PR DESCRIPTION
This PR adds a comprehensive AI Agent Context section to the README to help AI agents better understand the project structure, capabilities, and dependencies for cross-project editing.

## Changes
- Added 🤖 AI Agent Context section with:
  - Service purpose and key capabilities
  - Communication patterns
  - Technology stack details
  - External dependencies
  - API specifications
  - Project structure details

This improves AI agent understanding of the project for better code assistance and cross-project awareness.